### PR TITLE
feat: add role to sync GitHub ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ project requirements.
 
 Tested with ansible-lint >=24.2.0 releases and the current development version
 of ansible-core.
+
+## Available roles
+
+- `gewers.homelab.sync_github_ssh_key`: Syncs SSH public keys from a configurable GitHub profile into an account's
+  `authorized_keys` file using the `ansible.posix.authorized_key` module.

--- a/collections/ansible_collections/gewers/homelab/roles/sync_github_ssh_key/README.md
+++ b/collections/ansible_collections/gewers/homelab/roles/sync_github_ssh_key/README.md
@@ -1,0 +1,49 @@
+Sync GitHub SSH Key Role
+========================
+
+This role synchronizes a GitHub user's SSH public keys into the `authorized_keys` file of a target account. It fetches the
+keys directly from the GitHub API using Ansible's `url` lookup and ensures they are present by leveraging the
+`ansible.posix.authorized_key` module.
+
+Requirements
+------------
+
+The managed hosts must have an existing user account that can accept the configured SSH public keys.
+
+Role Variables
+--------------
+
+The role exposes the following variables which can be overridden as needed:
+
+- `sync_github_ssh_key_user`: Target user account whose `authorized_keys` file will be managed. Defaults to `toor`.
+- `sync_github_ssh_key_source_url`: URL used to retrieve the SSH public keys. Defaults to the GitHub keys endpoint for
+  `maximiliangewers`.
+
+Dependencies
+------------
+
+This role has no external role dependencies. Ensure the `ansible.posix` collection is available on the control node so the
+`authorized_key` module can be executed.
+
+Example Playbook
+----------------
+
+```yaml
+- name: Sync GitHub SSH keys for homelab administrators
+  hosts: homelab
+  roles:
+    - role: gewers.homelab.sync_github_ssh_key
+      vars:
+        sync_github_ssh_key_user: toor
+        sync_github_ssh_key_source_url: https://github.com/maximiliangewers.keys
+```
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Maintained by the Gewers homelab automation team.

--- a/collections/ansible_collections/gewers/homelab/roles/sync_github_ssh_key/defaults/main.yml
+++ b/collections/ansible_collections/gewers/homelab/roles/sync_github_ssh_key/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Default configuration for syncing a GitHub SSH public key into an authorized_keys file.
+sync_github_ssh_key_user: toor
+sync_github_ssh_key_source_url: https://github.com/maximiliangewers.keys

--- a/collections/ansible_collections/gewers/homelab/roles/sync_github_ssh_key/tasks/main.yml
+++ b/collections/ansible_collections/gewers/homelab/roles/sync_github_ssh_key/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure GitHub public key is authorized
+  ansible.posix.authorized_key:
+    user: "{{ sync_github_ssh_key_user }}"
+    state: present
+    key: "{{ lookup('ansible.builtin.url', sync_github_ssh_key_source_url, split_lines=False) }}"


### PR DESCRIPTION
## Summary
- add a new sync_github_ssh_key role that manages authorized_keys entries from a GitHub profile
- document the role variables and usage in a dedicated README
- list the role in the top-level project README for discoverability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d963580104832db3e893e207c9e188