### PR TITLE
test: configure maintenance molecule docker scenario

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -9,6 +9,8 @@ collections:
   - name: ansible.utils
     version: 4.0.0
 
+  - name: community.docker
+
   - name: cisco.ios
 
   - name: https://github.com/redhat-cop/network.backup

--- a/molecule/maintenance/create.yml
+++ b/molecule/maintenance/create.yml
@@ -3,33 +3,47 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  # no_log: "{{ molecule_no_log }}"
   tasks:
-    # TODO: Developer must implement and populate 'server' variable
+    - name: Pull required container images
+      community.docker.docker_image:
+        name: "{{ item.image }}"
+        source: pull
+      loop: "{{ molecule_yml.platforms }}"
 
-    - name: Create instance config
-      when: server.changed | default(false) | bool  # noqa no-handler
-      block:
-        - name: Populate instance config dict  # noqa jinja
-          ansible.builtin.set_fact:
-            instance_conf_dict: {}
-            # instance': "{{ }}",
-            # address': "{{ }}",
-            # user': "{{ }}",
-            # port': "{{ }}",
-            # 'identity_file': "{{ }}", }
-          with_items: "{{ server.results }}"
-          register: instance_config_dict
+    - name: Ensure Molecule instance(s) are running
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.name }}"
+        image: "{{ item.image }}"
+        state: started
+        recreate: true
+        command: {{ item.command | default(omit) }}
+        privileged: {{ item.privileged | default(false) }}
+        tty: {{ item.tty | default(false) }}
+        env: {{ item.environment | default({}) }}
+        volumes: {{ item.volumes | default([]) }}
+        tmpfs: {{ item.tmpfs | default([]) }}
+      loop: "{{ molecule_yml.platforms }}"
+      register: server
 
-        - name: Convert instance config dict to a list
-          ansible.builtin.set_fact:
-            instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+    - name: Build instance configuration
+      ansible.builtin.set_fact:
+        instance_conf: "{{ (instance_conf | default([])) + [
+          {
+            'instance': item.item.name,
+            'address': item.item.address | default(item.item.name),
+            'user': item.item.ansible_user | default('root'),
+            'port': item.item.ansible_port | default('22'),
+            'identity_file': item.item.identity_file | default('')
+          }
+        ] }}"
+      loop: "{{ server.results }}"
 
-        - name: Dump instance config
-          ansible.builtin.copy:
-            content: |
-              # Molecule managed
+    - name: Dump instance config
+      ansible.builtin.copy:
+        content: |
+          # Molecule managed
 
-              {{ instance_conf | to_json | from_json | to_yaml }}
-            dest: "{{ molecule_instance_config }}"
-            mode: "0600"
+          {{ instance_conf | to_json | from_json | to_yaml }}
+        dest: "{{ molecule_instance_config }}"
+        mode: "0600"

--- a/molecule/maintenance/destroy.yml
+++ b/molecule/maintenance/destroy.yml
@@ -5,20 +5,18 @@
   gather_facts: false
   # no_log: "{{ molecule_no_log }}"
   tasks:
-    # Developer must implement.
+    - name: Stop and remove Molecule instance(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: true
+      loop: "{{ molecule_yml.platforms }}"
 
-    # Mandatory configuration for Molecule to function.
-
-    - name: Populate instance config
-      ansible.builtin.set_fact:
-        instance_conf: {}
-
-    - name: Dump instance config
+    - name: Reset instance config
       ansible.builtin.copy:
         content: |
           # Molecule managed
 
-          {{ instance_conf | to_json | from_json | to_yaml }}
+          []
         dest: "{{ molecule_instance_config }}"
         mode: "0600"
-      when: server.changed | default(false) | bool  # noqa no-handler

--- a/molecule/maintenance/molecule.yml
+++ b/molecule/maintenance/molecule.yml
@@ -1,8 +1,31 @@
 ---
+dependency:
+  name: galaxy
+
 driver:
-  name: default
+  name: docker
+
 platforms:
-  - name: instance
-    # you might want to add your own variables here based on what provisioning
-    # you are doing like:
-    # image: quay.io/centos/centos:stream8
+  - name: maintenance-instance
+    image: ghcr.io/geerlingguy/docker-ubuntu2204-ansible:latest
+    command: /lib/systemd/systemd
+    privileged: true
+    tty: true
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      maintenance-instance:
+        ansible_connection: community.docker.docker
+        ansible_python_interpreter: /usr/bin/python3
+
+verifier:
+  name: ansible


### PR DESCRIPTION
## Summary
- configure the maintenance Molecule scenario to start an Ubuntu systemd-enabled container
- add the community.docker collection dependency required by the scenario

## Testing
- molecule test --scenario-name maintenance *(fails: unable to clone https://github.com/redhat-cop/network.backup due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68d98e85ec20832dac8f8ccacd884c90