### PR TITLE
test: validate maintenance workflow with bash

### DIFF
--- a/.github/actions/ansible-setup/action.yml
+++ b/.github/actions/ansible-setup/action.yml
@@ -1,0 +1,22 @@
+name: Ansible setup
+description: Install Ansible and collection requirements for tests
+runs:
+  using: composite
+  steps:
+    - name: Upgrade pip
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install Ansible tooling
+      shell: bash
+      run: |
+        python -m pip install ansible-core ansible-lint
+    - name: Install collection requirements
+      shell: bash
+      run: |
+        if [ -f collections/requirements.yml ]; then
+          ansible-galaxy collection install \
+            --force \
+            --collections-path collections \
+            -r collections/requirements.yml
+        fi

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,80 @@
+name: test: maintenance playbook
+
+on:
+  pull_request:
+    paths:
+      - maintenance.yml
+      - .github/workflows/maintenance.yml
+      - .github/actions/ansible-setup/**
+      - tests/maintenance/**
+
+jobs:
+  maintenance:
+    name: Maintenance smoke test (ansible ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ansible tooling
+        uses: ./.github/actions/ansible-setup
+
+      - name: Validate maintenance playbook syntax
+        run: ansible-playbook maintenance.yml --syntax-check
+
+      - name: Apply maintenance playbook against test inventory
+        env:
+          ANSIBLE_FORCE_COLOR: "0"
+        run: |
+          ansible-playbook maintenance.yml \
+            -i tests/maintenance/inventory/hosts.ini \
+            --diff | tee maintenance.log
+
+      - name: Verify GitHub SSH key was applied
+        shell: bash
+        run: |
+          set -euo pipefail
+          AUTH_KEYS="$HOME/.ssh/authorized_keys"
+          if [[ ! -f "$AUTH_KEYS" ]]; then
+            echo "Expected $AUTH_KEYS to exist after maintenance playbook run" >&2
+            exit 1
+          fi
+          if ! grep -Fq 'vagrant insecure public key' "$AUTH_KEYS"; then
+            echo "Expected test SSH key to be present in $AUTH_KEYS" >&2
+            exit 1
+          fi
+
+      - name: Assert maintenance playbook completed without failures
+        shell: bash
+        run: |
+          set -euo pipefail
+          recap_line=$(grep -A1 '^PLAY RECAP' maintenance.log | tail -n1 || true)
+          if [[ -z "$recap_line" ]]; then
+            echo "Unable to locate PLAY RECAP in Ansible output" >&2
+            exit 1
+          fi
+          if [[ "$recap_line" =~ ok=([0-9]+) ]]; then
+            ok_count=${BASH_REMATCH[1]}
+          else
+            echo "Could not parse ok count from recap: $recap_line" >&2
+            exit 1
+          fi
+          if [[ "$recap_line" =~ failed=([0-9]+) ]]; then
+            failed_count=${BASH_REMATCH[1]}
+          else
+            echo "Could not parse failed count from recap: $recap_line" >&2
+            exit 1
+          fi
+          if (( ok_count == 0 )); then
+            echo "Maintenance playbook did not execute any tasks" >&2
+            exit 1
+          fi
+          if (( failed_count != 0 )); then
+            echo "Maintenance playbook reported failures: $recap_line" >&2
+            exit 1
+          fi

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -1,5 +1,5 @@
 ---
-- name: Perform routine maintenance
+- name: Perform routine maintenance tasks
   hosts: "all:!switches"
   become: true
   roles:

--- a/tests/maintenance/inventory/group_vars/all.yml
+++ b/tests/maintenance/inventory/group_vars/all.yml
@@ -1,0 +1,5 @@
+---
+# Variables used to exercise the maintenance playbook in CI.
+sync_github_ssh_key_user: "{{ lookup('ansible.builtin.env', 'USER') | default('runner', true) }}"
+sync_github_ssh_key_source_url: https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub
+update_linux_deps_autoremove: false

--- a/tests/maintenance/inventory/hosts.ini
+++ b/tests/maintenance/inventory/hosts.ini
@@ -1,0 +1,4 @@
+[all]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+
+[switches]


### PR DESCRIPTION
## Summary
- replace the python validation scripts in the maintenance workflow with bash equivalents to satisfy testing requirements

## Testing
- ansible-playbook maintenance.yml --syntax-check

------
https://chatgpt.com/codex/tasks/task_e_68da0e5a128c832da3d8a8440f68cd40